### PR TITLE
Add crypto screener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # crypto-screener
+
+This repository contains a simple cryptocurrency screener implemented in Python.
+
+## Usage
+
+Run the screener to fetch the top cryptocurrencies by market cap and display those with a 24‑hour price change above a threshold:
+
+```bash
+python screener.py --per-page 10 --threshold 5
+```
+
+The script uses the public CoinGecko API. Network access is required for real data; the included tests mock API responses.

--- a/screener.py
+++ b/screener.py
@@ -1,0 +1,50 @@
+import json
+from urllib import request, parse
+
+COINGECKO_MARKETS_URL = 'https://api.coingecko.com/api/v3/coins/markets'
+
+
+def fetch_market_data(vs_currency='usd', per_page=10, page=1):
+    """Fetch market data for cryptocurrencies from CoinGecko."""
+    params = {
+        'vs_currency': vs_currency,
+        'order': 'market_cap_desc',
+        'per_page': per_page,
+        'page': page,
+        'price_change_percentage': '24h'
+    }
+    url = COINGECKO_MARKETS_URL + '?' + parse.urlencode(params)
+    with request.urlopen(url) as resp:
+        data = json.loads(resp.read().decode())
+    return data
+
+
+def screen_by_price_change(data, pct_threshold=5.0):
+    """Filter coins whose 24h change percentage is above pct_threshold."""
+    screened = []
+    for coin in data:
+        change = coin.get('price_change_percentage_24h')
+        if change is not None and change >= pct_threshold:
+            screened.append(coin)
+    return screened
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description='Simple crypto screener using CoinGecko API')
+    parser.add_argument('--per-page', type=int, default=10, help='Number of coins to fetch')
+    parser.add_argument('--threshold', type=float, default=5.0, help='24h percentage change threshold')
+    args = parser.parse_args()
+
+    data = fetch_market_data(per_page=args.per_page)
+    screened = screen_by_price_change(data, pct_threshold=args.threshold)
+    for coin in screened:
+        name = coin.get('name')
+        symbol = coin.get('symbol', '').upper()
+        price = coin.get('current_price')
+        change = coin.get('price_change_percentage_24h')
+        print(f"{name} ({symbol}): {price} USD, 24h change {change}%")
+
+
+if __name__ == '__main__':
+    main()

--- a/test_screener.py
+++ b/test_screener.py
@@ -1,0 +1,37 @@
+import json
+from unittest.mock import patch, MagicMock
+
+import screener
+
+sample_data = [
+    {
+        'id': 'bitcoin',
+        'symbol': 'btc',
+        'name': 'Bitcoin',
+        'current_price': 30000,
+        'price_change_percentage_24h': 10.0,
+    },
+    {
+        'id': 'ethereum',
+        'symbol': 'eth',
+        'name': 'Ethereum',
+        'current_price': 2000,
+        'price_change_percentage_24h': 3.0,
+    },
+]
+
+
+@patch('urllib.request.urlopen')
+def test_fetch_market_data(mock_urlopen):
+    mock_response = MagicMock()
+    mock_response.read.return_value = json.dumps(sample_data).encode()
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+
+    data = screener.fetch_market_data(per_page=2)
+    assert data == sample_data
+    assert mock_urlopen.called
+
+
+def test_screen_by_price_change():
+    filtered = screener.screen_by_price_change(sample_data, pct_threshold=5)
+    assert filtered == [sample_data[0]]


### PR DESCRIPTION
## Summary
- implement a simple cryptocurrency screener using the CoinGecko API
- add tests mocking API responses
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884944f4960832195bb311d618d8d67