### PR TITLE
Add tests for CoinGecko trending API

### DIFF
--- a/test_screener.py
+++ b/test_screener.py
@@ -20,6 +20,28 @@ sample_data = [
     },
 ]
 
+# Mock data for the /search/trending endpoint
+trending_json = {
+    "coins": [
+        {
+            "item": {
+                "id": "bitcoin",
+                "name": "Bitcoin",
+                "symbol": "BTC",
+                "price_btc": 1.0,
+            }
+        },
+        {
+            "item": {
+                "id": "ethereum",
+                "name": "Ethereum",
+                "symbol": "ETH",
+                "price_btc": 0.065,
+            }
+        },
+    ]
+}
+
 
 @patch('urllib.request.urlopen')
 def test_fetch_market_data(mock_urlopen):
@@ -35,3 +57,18 @@ def test_fetch_market_data(mock_urlopen):
 def test_screen_by_price_change():
     filtered = screener.screen_by_price_change(sample_data, pct_threshold=5)
     assert filtered == [sample_data[0]]
+
+
+@patch('screener_ui.requests.get')
+def test_get_coingecko_trending(mock_get):
+    import screener_ui
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = trending_json
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    df = screener_ui.get_coingecko_trending()
+    assert {"name", "symbol", "price"}.issubset(df.columns)
+    assert len(df) == len(trending_json["coins"])
+    assert mock_get.called


### PR DESCRIPTION
## Summary
- add mock data for CoinGecko `/search/trending`
- test `get_coingecko_trending` by patching `requests.get`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ca1fa70c83218c6d5c886434bd4d